### PR TITLE
Add Respoke-SDK header to requests

### DIFF
--- a/src/Respoke.php
+++ b/src/Respoke.php
@@ -15,7 +15,14 @@ class Client {
     private $guzzle;
     private $tokenId;
     private $log;
-    
+
+    private function getSDKHeader() {
+        $phpVersion = phpversion();
+        $respokeVersion = json_decode(file_get_contents(realpath(__DIR__ .'/../composer.json')))->version;
+        $osVersion = sprintf('%s %s', php_uname('s'), php_uname('r'));
+        return sprintf('Respoke-PHP/%s (%s) PHP/%s', $respokeVersion, $osVersion, $phpVersion);
+    }
+
     public function __construct($args = []) {
         $this->appId = @$args["appId"];
         $this->appSecret = @$args["appSecret"];
@@ -28,7 +35,8 @@ class Client {
             'defaults' => [
                 'headers' => [
                     'Content-type' => 'application/json',
-                    'App-Secret' => $this->appSecret
+                    'App-Secret' => $this->appSecret,
+                    'Respoke-SDK' => $this->getSDKHeader()
                 ]
             ]
         ]);


### PR DESCRIPTION
This patch adds a "Respoke-SDK" header to all requests, to help
Respoke get more insight into which client libraries are being used
and what environments they are being run in. The header contains
The version of the respoke-php client library, the os and version,
and the version of php being used.

<img width="799" alt="screen shot 2015-09-23 at 8 16 06 pm" src="https://cloud.githubusercontent.com/assets/309219/10063274/74e95018-6231-11e5-8dea-2347131f0f3c.png">

Related to MER-4340.
